### PR TITLE
[WEBSITE-399] Implemented the handling of query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Parliament::Request.new.base_url #=> 'http://example.com'
 
 
 ### Building an 'endpoint'
-Now that we have a `base_url` set, we will want to build an 'endpoint' such as: `http://test.com/parties/current.nt`.
+Now that we have a `base_url` set, we will want to build an 'endpoint' such as: `http://test.com/parties/current`.
 
 An endpoint is effectively just a full URL to an n-triple file on a remote server.
 
@@ -78,13 +78,13 @@ Building an endpoint is simple, once you have a Parliament::Request object, you 
 ```ruby
 parliament = Parliament::Request.new(base_url: 'http://test.com') #=>  #<Parliament::Request>
 
-# target endpoint: 'http://test.com/parties/current.nt'
+# target endpoint: 'http://test.com/parties/current'
 parliament.parties.current.get
 
-# target endpoint: 'http://test.com/parties/123/people/current.nt'
+# target endpoint: 'http://test.com/parties/123/people/current'
 parliament.parties('123').people.current.get
 
-# target endpoint: 'http://test.com/people/123/letters/456.nt'
+# target endpoint: 'http://test.com/people/123/letters/456'
 parliament.people('123').letters('456').get
 ```
 

--- a/lib/parliament/decorators/party_membership.rb
+++ b/lib/parliament/decorators/party_membership.rb
@@ -17,6 +17,8 @@ module Parliament
         has_end_date = respond_to?(:partyMembershipEndDate)
 
         !has_end_date
+        
+        respond_to?(:partyMembershipStartDate) ? Time.parse(partyMembershipStartDate) : nil
       end
     end
   end

--- a/lib/parliament/decorators/party_membership.rb
+++ b/lib/parliament/decorators/party_membership.rb
@@ -17,8 +17,6 @@ module Parliament
         has_end_date = respond_to?(:partyMembershipEndDate)
 
         !has_end_date
-        
-        respond_to?(:partyMembershipStartDate) ? Time.parse(partyMembershipStartDate) : nil
       end
     end
   end

--- a/lib/parliament/request.rb
+++ b/lib/parliament/request.rb
@@ -68,7 +68,7 @@ module Parliament
     end
 
     def api_endpoint
-      [@base_url, @endpoint_parts].join('/') + '.nt'
+      [@base_url, @endpoint_parts].join('/')
     end
   end
 end

--- a/lib/parliament/request.rb
+++ b/lib/parliament/request.rb
@@ -22,10 +22,10 @@ module Parliament
     end
 
     def get(params: nil)
-      endpoint = api_endpoint
-      endpoint = add_query_params(endpoint, params) unless params.nil?
+      endpoint_uri = URI.parse(api_endpoint)
+      endpoint_uri.query = URI.encode_www_form(params.to_a) unless params.nil?
 
-      net_response = Net::HTTP.get_response(URI(endpoint))
+      net_response = Net::HTTP.get_response(URI(endpoint_uri))
 
       handle_errors(net_response)
 
@@ -72,14 +72,6 @@ module Parliament
 
     def api_endpoint
       [@base_url, @endpoint_parts].join('/')
-    end
-
-    def add_query_params(endpoint, params)
-      endpoint += '?'
-      params.each do |param_key, param_value|
-        endpoint += param_key.to_s + '=' + param_value.to_s + '&'
-      end
-      endpoint.chop
     end
   end
 end

--- a/lib/parliament/request.rb
+++ b/lib/parliament/request.rb
@@ -21,8 +21,11 @@ module Parliament
       (method != :base_url=) || super
     end
 
-    def get
-      net_response = Net::HTTP.get_response(URI(api_endpoint))
+    def get(params: nil)
+      endpoint = api_endpoint
+      endpoint = add_query_params(endpoint, params) unless params.nil?
+
+      net_response = Net::HTTP.get_response(URI(endpoint))
 
       handle_errors(net_response)
 
@@ -69,6 +72,14 @@ module Parliament
 
     def api_endpoint
       [@base_url, @endpoint_parts].join('/')
+    end
+
+    def add_query_params(endpoint, params)
+      endpoint += '?'
+      params.each do |param_key, param_value|
+        endpoint += param_key.to_s + '=' + param_value.to_s + '&'
+      end
+      endpoint.chop
     end
   end
 end

--- a/parliament-ruby.gemspec
+++ b/parliament-ruby.gemspec
@@ -30,6 +30,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.12.0'
   spec.add_development_dependency 'vcr', '~> 3.0.3'
   spec.add_development_dependency 'webmock', '~> 2.3.2'
-  spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'pry-nav'
 end

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyArea/_latitude/constituency_has_a_latitude/returns_the_latitude_of_the_constituency_area.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyArea/_latitude/constituency_has_a_latitude/returns_the_latitude_of_the_constituency_area.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894.nt
+    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyArea/_latitude/constituency_has_no_latitude/returns_an_empty_string.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyArea/_latitude/constituency_has_no_latitude/returns_an_empty_string.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894.nt
+    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyArea/_longitude/constituency_has_a_longitude/returns_the_longitude_of_the_constituency_area.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyArea/_longitude/constituency_has_a_longitude/returns_the_longitude_of_the_constituency_area.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894.nt
+    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyArea/_longitude/constituency_has_no_longitude/returns_an_empty_string.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyArea/_longitude/constituency_has_no_longitude/returns_an_empty_string.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894.nt
+    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyArea/_polygon/constituency_has_a_polygon/returns_the_polygon_of_the_constituency_area.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyArea/_polygon/constituency_has_a_polygon/returns_the_polygon_of_the_constituency_area.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894.nt
+    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyArea/_polygon/constituency_has_no_polygon/returns_an_empty_string.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyArea/_polygon/constituency_has_no_polygon/returns_an_empty_string.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894.nt
+    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_area/constituency_has_an_area/returns_the_area.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_area/constituency_has_an_area/returns_the_area.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894.nt
+    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_area/constituency_has_no_seat_incumbencies/returns_nil.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_area/constituency_has_no_seat_incumbencies/returns_nil.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894.nt
+    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_contact_points/constituency_has_contact_points/returns_an_array_of_contact_points.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_contact_points/constituency_has_contact_points/returns_an_array_of_contact_points.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894.nt
+    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_contact_points/constituency_has_no_contact_points/returns_an_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_contact_points/constituency_has_no_contact_points/returns_an_empty_array.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894.nt
+    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_end_date/constituency_has_an_end_date/returns_the_end_date_of_the_constituency.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_end_date/constituency_has_an_end_date/returns_the_end_date_of_the_constituency.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894.nt
+    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_end_date/constituency_has_no_end_date/returns_an_empty_string.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_end_date/constituency_has_no_end_date/returns_an_empty_string.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894.nt
+    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_members/constituency_has_members/returns_an_array_of_members.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_members/constituency_has_members/returns_an_array_of_members.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894.nt
+    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_members/constituency_has_no_seat_incumbencies/returns_an_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_members/constituency_has_no_seat_incumbencies/returns_an_empty_array.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894.nt
+    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_name/constituency_has_a_name/returns_the_name_of_the_constituency.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_name/constituency_has_a_name/returns_the_name_of_the_constituency.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894.nt
+    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_name/constituency_has_no_name/returns_an_empty_string.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_name/constituency_has_no_name/returns_an_empty_string.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894.nt
+    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_seat_incumbencies/constituency_has_no_seat_incumbencies/returns_an_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_seat_incumbencies/constituency_has_no_seat_incumbencies/returns_an_empty_array.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894.nt
+    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_seat_incumbencies/constituency_has_seat_incumbencies/returns_an_array_of_seat_incumbencies.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_seat_incumbencies/constituency_has_seat_incumbencies/returns_an_array_of_seat_incumbencies.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894.nt
+    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_seats/constituency_has_house_seats/returns_an_array_of_house_seats.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_seats/constituency_has_house_seats/returns_an_array_of_house_seats.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894.nt
+    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_seats/constituency_has_no_house_seats/returns_an_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_seats/constituency_has_no_house_seats/returns_an_empty_array.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894.nt
+    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_start_date/constituency_has_a_start_date/returns_the_start_date_of_the_constituency.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_start_date/constituency_has_a_start_date/returns_the_start_date_of_the_constituency.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894.nt
+    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_start_date/constituency_has_no_start_date/returns_an_empty_string.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ConstituencyGroup/_start_date/constituency_has_no_start_date/returns_an_empty_string.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894.nt
+    uri: http://localhost:3030/constituencies/a2ce856d-ba0a-4508-9dd0-62feb54d3894
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ContactPoint/_email/Grom_Node_has_all_the_required_objects/returns_the_email_for_a_Grom_Node_object_of_type_ContactPoint.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ContactPoint/_email/Grom_Node_has_all_the_required_objects/returns_the_email_for_a_Grom_Node_object_of_type_ContactPoint.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47.nt
+    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ContactPoint/_email/Grom_Node_has_no_email/returns_an_empty_string.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ContactPoint/_email/Grom_Node_has_no_email/returns_an_empty_string.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47.nt
+    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ContactPoint/_fax_number/Grom_Node_has_all_the_required_objects/returns_the_fax_number_for_a_Grom_Node_object_of_type_ContactPoint.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ContactPoint/_fax_number/Grom_Node_has_all_the_required_objects/returns_the_fax_number_for_a_Grom_Node_object_of_type_ContactPoint.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47.nt
+    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ContactPoint/_fax_number/Grom_Node_has_no_fax_number/returns_an_empty_string.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ContactPoint/_fax_number/Grom_Node_has_no_fax_number/returns_an_empty_string.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47.nt
+    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ContactPoint/_person/Grom_Node_has_all_the_required_objects/returns_the_object_of_type_Person_for_a_Grom_Node_object_of_type_ContactPoint.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ContactPoint/_person/Grom_Node_has_all_the_required_objects/returns_the_object_of_type_Person_for_a_Grom_Node_object_of_type_ContactPoint.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47.nt
+    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ContactPoint/_person/Grom_Node_has_no_person_associated_with_it/returns_an_empty_string.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ContactPoint/_person/Grom_Node_has_no_person_associated_with_it/returns_an_empty_string.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47.nt
+    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ContactPoint/_phone_number/Grom_Node_has_all_the_required_objects/returns_the_phone_number_for_a_Grom_Node_object_of_type_ContactPoint.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ContactPoint/_phone_number/Grom_Node_has_all_the_required_objects/returns_the_phone_number_for_a_Grom_Node_object_of_type_ContactPoint.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47.nt
+    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ContactPoint/_phone_number/Grom_Node_has_no_phone_number/returns_an_empty_string.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ContactPoint/_phone_number/Grom_Node_has_no_phone_number/returns_an_empty_string.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47.nt
+    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ContactPoint/_postal_addresses/Grom_Node_has_all_the_required_objects/returns_the_postal_addresses_for_a_Grom_Node_object_of_type_ContactPoint.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ContactPoint/_postal_addresses/Grom_Node_has_all_the_required_objects/returns_the_postal_addresses_for_a_Grom_Node_object_of_type_ContactPoint.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47.nt
+    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_ContactPoint/_postal_addresses/Grom_Node_has_no_postal_addresses/returns_an_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_ContactPoint/_postal_addresses/Grom_Node_has_no_postal_addresses/returns_an_empty_array.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47.nt
+    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Gender/_name/Grom_Node_has_all_the_required_objects/returns_the_name_for_a_Grom_Node_object_of_type_Gender.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Gender/_name/Grom_Node_has_all_the_required_objects/returns_the_name_for_a_Grom_Node_object_of_type_Gender.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Gender/_name/Grom_Node_has_no_name/returns_an_empty_string.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Gender/_name/Grom_Node_has_no_name/returns_an_empty_string.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_GenderIdentity/_gender/Grom_Node_has_all_the_required_objects/returns_the_gender_for_a_Grom_Node_object_of_type_GenderIdentity.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_GenderIdentity/_gender/Grom_Node_has_all_the_required_objects/returns_the_gender_for_a_Grom_Node_object_of_type_GenderIdentity.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_GenderIdentity/_gender/Grom_Node_has_no_gender/returns_nil.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_GenderIdentity/_gender/Grom_Node_has_no_gender/returns_nil.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_House/_name/Grom_Node_has_all_the_required_objects/returns_the_name_for_a_Grom_Node_object_of_type_House.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_House/_name/Grom_Node_has_all_the_required_objects/returns_the_name_for_a_Grom_Node_object_of_type_House.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_House/_name/Grom_Node_has_no_name/returns_an_empty_string.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_House/_name/Grom_Node_has_no_name/returns_an_empty_string.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_House/_seat_incumbencies/Grom_Node_has_all_the_required_objects/returns_the_seat_incumbencies_for_a_Grom_Node_object_of_type_House.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_House/_seat_incumbencies/Grom_Node_has_all_the_required_objects/returns_the_seat_incumbencies_for_a_Grom_Node_object_of_type_House.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/houses.nt
+    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/houses
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_House/_seat_incumbencies/Grom_Node_has_no_seat_incumbencies/returns_an_empty_string.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_House/_seat_incumbencies/Grom_Node_has_no_seat_incumbencies/returns_an_empty_string.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/houses.nt
+    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/houses
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_House/_seats/Grom_Node_has_all_the_required_objects/returns_the_seats_for_a_Grom_Node_object_of_type_House.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_House/_seats/Grom_Node_has_all_the_required_objects/returns_the_seats_for_a_Grom_Node_object_of_type_House.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/houses.nt
+    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/houses
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_House/_seats/Grom_Node_has_no_seats/returns_an_empty_string.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_House/_seats/Grom_Node_has_no_seats/returns_an_empty_string.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/houses.nt
+    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/houses
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_HouseSeat/_constituency/Grom_Node_has_all_the_required_objects/returns_the_constituency_for_a_Grom_Node_object_of_type_HouseSeat.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_HouseSeat/_constituency/Grom_Node_has_all_the_required_objects/returns_the_constituency_for_a_Grom_Node_object_of_type_HouseSeat.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_HouseSeat/_constituency/Grom_Node_has_no_constituency/returns_nil.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_HouseSeat/_constituency/Grom_Node_has_no_constituency/returns_nil.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_HouseSeat/_house/Grom_Node_has_all_the_required_objects/returns_the_house_for_a_Grom_Node_object_of_type_HouseSeat.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_HouseSeat/_house/Grom_Node_has_all_the_required_objects/returns_the_house_for_a_Grom_Node_object_of_type_HouseSeat.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_HouseSeat/_house/Grom_Node_has_no_house/returns_nil.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_HouseSeat/_house/Grom_Node_has_no_house/returns_nil.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_HouseSeat/_seat_incumbencies/Grom_Node_has_all_the_required_objects/returns_the_seat_incumbencies_for_a_Grom_Node_object_of_type_HouseSeat.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_HouseSeat/_seat_incumbencies/Grom_Node_has_all_the_required_objects/returns_the_seat_incumbencies_for_a_Grom_Node_object_of_type_HouseSeat.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_HouseSeat/_seat_incumbencies/Grom_Node_has_no_seat_incumbencies/returns_an_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_HouseSeat/_seat_incumbencies/Grom_Node_has_no_seat_incumbencies/returns_an_empty_array.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Party/_name/Grom_Node_does_not_have_have_a_name/confirms_that_the_name_for_this_Grom_Node_node_does_not_exist.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Party/_name/Grom_Node_does_not_have_have_a_name/confirms_that_the_name_for_this_Grom_Node_node_does_not_exist.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Party/_name/Grom_Node_has_all_the_required_objects/confirms_that_the_type_for_this_Grom_Node_object_is_Party.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Party/_name/Grom_Node_has_all_the_required_objects/confirms_that_the_type_for_this_Grom_Node_object_is_Party.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Party/_name/Grom_Node_has_all_the_required_objects/returns_the_name_of_the_party_for_the_Grom_Node_object.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Party/_name/Grom_Node_has_all_the_required_objects/returns_the_name_of_the_party_for_the_Grom_Node_object.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Party/_party_memberships/Grom_Node_has_all_the_required_objects/returns_the_party_memberships_for_a_Grom_Node_object_of_type_Party.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Party/_party_memberships/Grom_Node_has_all_the_required_objects/returns_the_party_memberships_for_a_Grom_Node_object_of_type_Party.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff/parties.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff/parties
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Party/_party_memberships/Grom_Node_has_no_name/returns_an_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Party/_party_memberships/Grom_Node_has_no_name/returns_an_empty_array.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff/parties.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff/parties
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_PartyMembership/_current_/Grom_Node_returns_the_correct_value_for_a_current_or_non_current_party_membership.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_PartyMembership/_current_/Grom_Node_returns_the_correct_value_for_a_current_or_non_current_party_membership.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_PartyMembership/_end_date/Grom_Node_has_all_the_required_objects/returns_the_end_date_for_a_Grom_Node_object_of_type_PartyMembership.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_PartyMembership/_end_date/Grom_Node_has_all_the_required_objects/returns_the_end_date_for_a_Grom_Node_object_of_type_PartyMembership.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_PartyMembership/_end_date/Grom_Node_has_no_end_date/returns_nil.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_PartyMembership/_end_date/Grom_Node_has_no_end_date/returns_nil.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_PartyMembership/_party/Grom_Node_has_all_the_required_objects/returns_the_party_for_a_Grom_Node_object_of_type_PartyMembership.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_PartyMembership/_party/Grom_Node_has_all_the_required_objects/returns_the_party_for_a_Grom_Node_object_of_type_PartyMembership.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_PartyMembership/_party/Grom_Node_has_no_parties/returns_an_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_PartyMembership/_party/Grom_Node_has_no_parties/returns_an_empty_array.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_PartyMembership/_start_date/Grom_Node_has_all_the_required_objects/returns_the_start_date_for_a_Grom_Node_object_of_type_PartyMembership.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_PartyMembership/_start_date/Grom_Node_has_all_the_required_objects/returns_the_start_date_for_a_Grom_Node_object_of_type_PartyMembership.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_PartyMembership/_start_date/Grom_Node_has_no_start_date/returns_nil.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_PartyMembership/_start_date/Grom_Node_has_no_start_date/returns_nil.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_constituencies/Grom_Node_has_all_the_required_objects/returns_the_parties_for_a_Grom_Node_objects_of_type_Person.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_constituencies/Grom_Node_has_all_the_required_objects/returns_the_parties_for_a_Grom_Node_objects_of_type_Person.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_constituencies/Grom_Node_has_no_constituencies/returns_an_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_constituencies/Grom_Node_has_no_constituencies/returns_an_empty_array.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_contact_points/Grom_Node_has_all_the_required_objects/returns_the_contact_points_for_a_Grom_Node_object_of_type_Person.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_contact_points/Grom_Node_has_all_the_required_objects/returns_the_contact_points_for_a_Grom_Node_object_of_type_Person.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47.nt
+    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_contact_points/Grom_Node_has_no_contact_points/returns_an_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_contact_points/Grom_Node_has_no_contact_points/returns_an_empty_array.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47.nt
+    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_date_of_birth/Grom_Node_has_all_the_required_objects/returns_the_date_of_birth_for_a_Grom_Node_objects_of_type_Person.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_date_of_birth/Grom_Node_has_all_the_required_objects/returns_the_date_of_birth_for_a_Grom_Node_objects_of_type_Person.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_date_of_birth/Grom_Node_has_no_personDateOfBirth/returns_nil.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_date_of_birth/Grom_Node_has_no_personDateOfBirth/returns_nil.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_family_name/Grom_Node_has_all_the_required_objects/returns_the_given_name_for_a_Grom_Node_objects_of_type_Person.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_family_name/Grom_Node_has_all_the_required_objects/returns_the_given_name_for_a_Grom_Node_objects_of_type_Person.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_family_name/Grom_Node_has_no_personGivenName/returns_an_empty_string.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_family_name/Grom_Node_has_no_personGivenName/returns_an_empty_string.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_full_name/Grom_Node_has_all_the_required_objects/returns_the_full_name_for_a_Grom_Node_objects_of_type_Person.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_full_name/Grom_Node_has_all_the_required_objects/returns_the_full_name_for_a_Grom_Node_objects_of_type_Person.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_full_name/Grom_Node_has_no_personFamilyName/returns_a_full_name_with_just_personGivenName.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_full_name/Grom_Node_has_no_personFamilyName/returns_a_full_name_with_just_personGivenName.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_full_name/Grom_Node_has_no_personGivenName/returns_a_full_name_with_just_personFamilyName.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_full_name/Grom_Node_has_no_personGivenName/returns_a_full_name_with_just_personFamilyName.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_full_name/Grom_Node_has_no_personGivenName_or_personFamilyName/returns_an_empty_string.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_full_name/Grom_Node_has_no_personGivenName_or_personFamilyName/returns_an_empty_string.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_gender/Grom_Node_has_all_the_required_objects/returns_the_gender_for_a_Grom_Node_object_of_type_Person.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_gender/Grom_Node_has_all_the_required_objects/returns_the_gender_for_a_Grom_Node_object_of_type_Person.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_gender/Grom_Node_has_no_gender/returns_nil.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_gender/Grom_Node_has_no_gender/returns_nil.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_gender_identities/Grom_Node_has_all_the_required_objects/returns_the_contact_points_for_a_Grom_Node_object_of_type_Person.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_gender_identities/Grom_Node_has_all_the_required_objects/returns_the_contact_points_for_a_Grom_Node_object_of_type_Person.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_gender_identities/Grom_Node_has_no_gender_identities/returns_an_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_gender_identities/Grom_Node_has_no_gender_identities/returns_an_empty_array.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_given_name/Grom_Node_has_all_the_required_objects/returns_the_given_name_for_a_Grom_Node_objects_of_type_Person.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_given_name/Grom_Node_has_all_the_required_objects/returns_the_given_name_for_a_Grom_Node_objects_of_type_Person.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_given_name/Grom_Node_has_no_personGivenName/returns_an_empty_string.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_given_name/Grom_Node_has_no_personGivenName/returns_an_empty_string.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_houses/Grom_Node_has_all_the_required_objects/returns_the_houses_for_a_Grom_Node_object_of_type_Person.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_houses/Grom_Node_has_all_the_required_objects/returns_the_houses_for_a_Grom_Node_object_of_type_Person.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_houses/Grom_Node_has_no_houses/returns_an_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_houses/Grom_Node_has_no_houses/returns_an_empty_array.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_other_name/Grom_Node_has_all_the_required_objects/returns_the_other_name_for_a_Grom_Node_objects_of_type_Person.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_other_name/Grom_Node_has_all_the_required_objects/returns_the_other_name_for_a_Grom_Node_objects_of_type_Person.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47.nt
+    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_other_name/Grom_Node_has_no_personGivenName/returns_an_empty_string.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_other_name/Grom_Node_has_no_personGivenName/returns_an_empty_string.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47.nt
+    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_parties/Grom_Node_has_all_the_required_objects/returns_the_parties_for_a_Grom_Node_objects_of_type_Person.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_parties/Grom_Node_has_all_the_required_objects/returns_the_parties_for_a_Grom_Node_objects_of_type_Person.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_parties/Grom_Node_has_no_parties/returns_an_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_parties/Grom_Node_has_no_parties/returns_an_empty_array.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_party_memberships/Grom_Node_has_all_the_required_objects/returns_the_party_memberships_for_a_Grom_Node_object_of_type_Person.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_party_memberships/Grom_Node_has_all_the_required_objects/returns_the_party_memberships_for_a_Grom_Node_object_of_type_Person.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_party_memberships/Grom_Node_has_no_party_memberships/returns_an_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_party_memberships/Grom_Node_has_no_party_memberships/returns_an_empty_array.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_seat_incumbencies/Grom_Node_has_all_the_required_objects/returns_the_seat_incumbencies_for_a_Grom_Node_object_of_type_Person.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_seat_incumbencies/Grom_Node_has_all_the_required_objects/returns_the_seat_incumbencies_for_a_Grom_Node_object_of_type_Person.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_seat_incumbencies/Grom_Node_has_no_seat_incumbencies/returns_an_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_seat_incumbencies/Grom_Node_has_no_seat_incumbencies/returns_an_empty_array.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_seats/Grom_Node_has_all_the_required_objects/returns_the_seats_for_a_Grom_Node_object_of_type_Person.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_seats/Grom_Node_has_all_the_required_objects/returns_the_seats_for_a_Grom_Node_object_of_type_Person.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_seats/Grom_Node_has_no_seats/returns_an_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_Person/_seats/Grom_Node_has_no_seats/returns_an_empty_array.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_PostalAddress/_full_address/Grom_Node_has_all_the_required_objects/returns_the_full_address_for_a_Grom_Node_object_of_type_PostalAddress.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_PostalAddress/_full_address/Grom_Node_has_all_the_required_objects/returns_the_full_address_for_a_Grom_Node_object_of_type_PostalAddress.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/8d895ffc-c2bf-43d2-b756-95ab3e987919/contact_point.nt
+    uri: http://localhost:3030/constituencies/8d895ffc-c2bf-43d2-b756-95ab3e987919/contact_point
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_PostalAddress/_full_address/Grom_Node_has_no_postal_addresses/returns_an_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_PostalAddress/_full_address/Grom_Node_has_no_postal_addresses/returns_an_empty_array.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/8d895ffc-c2bf-43d2-b756-95ab3e987919/contact_point.nt
+    uri: http://localhost:3030/constituencies/8d895ffc-c2bf-43d2-b756-95ab3e987919/contact_point
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_constituency/Grom_Node_has_all_the_required_objects/returns_the_constituency_for_a_Grom_Node_object_of_type_SeatIncumbency.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_constituency/Grom_Node_has_all_the_required_objects/returns_the_constituency_for_a_Grom_Node_object_of_type_SeatIncumbency.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_constituency/Grom_Node_has_no_constituency/returns_nil.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_constituency/Grom_Node_has_no_constituency/returns_nil.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_contact_points/constituency_has_no_contact_points/returns_an_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_contact_points/constituency_has_no_contact_points/returns_an_empty_array.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_contact_points/seat_incumbency_has_contact_points/returns_an_array_of_contact_points.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_contact_points/seat_incumbency_has_contact_points/returns_an_array_of_contact_points.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_current_/Grom_Node_returns_the_correct_value_for_a_current_or_non_current_seat_incumbency.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_current_/Grom_Node_returns_the_correct_value_for_a_current_or_non_current_seat_incumbency.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_end_date/seat_incumbency_has_an_end_date/returns_the_end_date_of_the_seat_incumbency.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_end_date/seat_incumbency_has_an_end_date/returns_the_end_date_of_the_seat_incumbency.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_end_date/seat_incumbency_has_no_end_date/returns_nil.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_end_date/seat_incumbency_has_no_end_date/returns_nil.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_house/Grom_Node_has_all_the_required_objects/returns_the_house_for_a_Grom_Node_object_of_type_SeatIncumbency.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_house/Grom_Node_has_all_the_required_objects/returns_the_house_for_a_Grom_Node_object_of_type_SeatIncumbency.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_house/Grom_Node_has_no_house/returns_nil.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_house/Grom_Node_has_no_house/returns_nil.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_member/Grom_Node_has_all_the_required_objects/returns_the_member_for_a_Grom_Node_object_of_type_SeatIncumbency.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_member/Grom_Node_has_all_the_required_objects/returns_the_member_for_a_Grom_Node_object_of_type_SeatIncumbency.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_member/Grom_Node_has_no_member/returns_nil.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_member/Grom_Node_has_no_member/returns_nil.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_seat/Grom_Node_has_all_the_required_objects/returns_the_seat_for_a_Grom_Node_object_of_type_SeatIncumbency.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_seat/Grom_Node_has_all_the_required_objects/returns_the_seat_for_a_Grom_Node_object_of_type_SeatIncumbency.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_seat/Grom_Node_has_no_seats/returns_an_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_seat/Grom_Node_has_no_seats/returns_an_empty_array.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_start_date/seat_incumbency_has_a_start_date/returns_the_start_date_of_the_seat_incumbency.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_start_date/seat_incumbency_has_a_start_date/returns_the_start_date_of_the_seat_incumbency.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_start_date/seat_incumbency_has_no_start_date/returns_an_empty_string.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_start_date/seat_incumbency_has_no_start_date/returns_an_empty_string.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_start_date/seat_incumbency_has_no_start_date/returns_nil.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Decorators_SeatIncumbency/_start_date/seat_incumbency_has_no_start_date/returns_nil.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Request/_assign_decorator/decorates_nested_objects.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Request/_assign_decorator/decorates_nested_objects.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/members/current.nt
+    uri: http://localhost:3030/people/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Request/_assign_decorator/returns_an_object_which_has_been_decorated_if_a_decorator_is_defined.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Request/_assign_decorator/returns_an_object_which_has_been_decorated_if_a_decorator_is_defined.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/members/current.nt
+    uri: http://localhost:3030/people/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Request/_get/it_accepts_query_parameters/returns_1_object.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Request/_get/it_accepts_query_parameters/returns_1_object.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people?by=mnisId&id=3898
+    uri: http://localhost:3030/people?id=3898&source=mnisId
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Request/_get/it_accepts_query_parameters/returns_1_object.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Request/_get/it_accepts_query_parameters/returns_1_object.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/people?by=mnisId&id=3898
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - localhost:3030
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/n-triples; charset=utf-8
+      Etag:
+      - W/"070ba81d6dda5d42fda1032187263084"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - d49bec10-10ca-47be-9ac3-799d0cba9b1e
+      X-Runtime:
+      - '0.030821'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        <http://id.ukpds.org/581ade57-3805-4a4a-82c9-8d622cb352a4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Person> .
+        <http://id.ukpds.org/581ade57-3805-4a4a-82c9-8d622cb352a4> <http://id.ukpds.org/schema/personGivenName> "Person - givenName" .
+        <http://id.ukpds.org/581ade57-3805-4a4a-82c9-8d622cb352a4> <http://id.ukpds.org/schema/personFamilyName> "Person - familyName" .
+    http_version: 
+  recorded_at: Tue, 21 Feb 2017 17:08:52 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Parliament_Request/_get/it_accepts_query_parameters/returns_a_Parliament_Response.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Request/_get/it_accepts_query_parameters/returns_a_Parliament_Response.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/people?by=mnisId&id=3898
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - localhost:3030
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/n-triples; charset=utf-8
+      Etag:
+      - W/"070ba81d6dda5d42fda1032187263084"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - d49bec10-10ca-47be-9ac3-799d0cba9b1e
+      X-Runtime:
+      - '0.030821'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        <http://id.ukpds.org/581ade57-3805-4a4a-82c9-8d622cb352a4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Person> .
+        <http://id.ukpds.org/581ade57-3805-4a4a-82c9-8d622cb352a4> <http://id.ukpds.org/schema/personGivenName> "Person - givenName" .
+        <http://id.ukpds.org/581ade57-3805-4a4a-82c9-8d622cb352a4> <http://id.ukpds.org/schema/personFamilyName> "Person - familyName" .
+    http_version:
+  recorded_at: Tue, 21 Feb 2017 17:08:52 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Parliament_Request/_get/it_accepts_query_parameters/returns_a_Parliament_Response.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Request/_get/it_accepts_query_parameters/returns_a_Parliament_Response.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people?by=mnisId&id=3898
+    uri: http://localhost:3030/people?id=3898&source=mnisId
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Request/_get/it_returns_a_status_code_in_either_the_400_or_500_range/and_raises_client_error_when_status_is_within_the_400_range.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Request/_get/it_returns_a_status_code_in_either_the_400_or_500_range/and_raises_client_error_when_status_is_within_the_400_range.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/dogs/cats
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - localhost:3030
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Request-Id:
+      - f9380e0d-550f-4036-9119-f84fb6afd1a4
+      X-Runtime:
+      - '0.009278'
+      Content-Length:
+      - '3686'
+    body:
+      encoding: UTF-8
+      string: '{"status":404,"error":"Not Found","exception":"#\u003cActionController::RoutingError:
+        No route matches [GET] \"/dogs/cats\"\u003e","traces":{"Application Trace":[],"Framework
+        Trace":[{"id":0,"trace":"actionpack (5.0.0.1) lib/action_dispatch/middleware/debug_exceptions.rb:53:in
+        `call''"},{"id":1,"trace":"actionpack (5.0.0.1) lib/action_dispatch/middleware/show_exceptions.rb:31:in
+        `call''"},{"id":2,"trace":"railties (5.0.0.1) lib/rails/rack/logger.rb:36:in
+        `call_app''"},{"id":3,"trace":"railties (5.0.0.1) lib/rails/rack/logger.rb:24:in
+        `block in call''"},{"id":4,"trace":"activesupport (5.0.0.1) lib/active_support/tagged_logging.rb:70:in
+        `block in tagged''"},{"id":5,"trace":"activesupport (5.0.0.1) lib/active_support/tagged_logging.rb:26:in
+        `tagged''"},{"id":6,"trace":"activesupport (5.0.0.1) lib/active_support/tagged_logging.rb:70:in
+        `tagged''"},{"id":7,"trace":"railties (5.0.0.1) lib/rails/rack/logger.rb:24:in
+        `call''"},{"id":8,"trace":"actionpack (5.0.0.1) lib/action_dispatch/middleware/request_id.rb:24:in
+        `call''"},{"id":9,"trace":"rack (2.0.1) lib/rack/runtime.rb:22:in `call''"},{"id":10,"trace":"activesupport
+        (5.0.0.1) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in
+        `call''"},{"id":11,"trace":"actionpack (5.0.0.1) lib/action_dispatch/middleware/executor.rb:12:in
+        `call''"},{"id":12,"trace":"actionpack (5.0.0.1) lib/action_dispatch/middleware/static.rb:136:in
+        `call''"},{"id":13,"trace":"rack (2.0.1) lib/rack/sendfile.rb:111:in `call''"},{"id":14,"trace":"railties
+        (5.0.0.1) lib/rails/engine.rb:522:in `call''"},{"id":15,"trace":"puma (3.6.0)
+        lib/puma/configuration.rb:225:in `call''"},{"id":16,"trace":"puma (3.6.0)
+        lib/puma/server.rb:578:in `handle_request''"},{"id":17,"trace":"puma (3.6.0)
+        lib/puma/server.rb:415:in `process_client''"},{"id":18,"trace":"puma (3.6.0)
+        lib/puma/server.rb:275:in `block in run''"},{"id":19,"trace":"puma (3.6.0)
+        lib/puma/thread_pool.rb:116:in `block in spawn_thread''"}],"Full Trace":[{"id":0,"trace":"actionpack
+        (5.0.0.1) lib/action_dispatch/middleware/debug_exceptions.rb:53:in `call''"},{"id":1,"trace":"actionpack
+        (5.0.0.1) lib/action_dispatch/middleware/show_exceptions.rb:31:in `call''"},{"id":2,"trace":"railties
+        (5.0.0.1) lib/rails/rack/logger.rb:36:in `call_app''"},{"id":3,"trace":"railties
+        (5.0.0.1) lib/rails/rack/logger.rb:24:in `block in call''"},{"id":4,"trace":"activesupport
+        (5.0.0.1) lib/active_support/tagged_logging.rb:70:in `block in tagged''"},{"id":5,"trace":"activesupport
+        (5.0.0.1) lib/active_support/tagged_logging.rb:26:in `tagged''"},{"id":6,"trace":"activesupport
+        (5.0.0.1) lib/active_support/tagged_logging.rb:70:in `tagged''"},{"id":7,"trace":"railties
+        (5.0.0.1) lib/rails/rack/logger.rb:24:in `call''"},{"id":8,"trace":"actionpack
+        (5.0.0.1) lib/action_dispatch/middleware/request_id.rb:24:in `call''"},{"id":9,"trace":"rack
+        (2.0.1) lib/rack/runtime.rb:22:in `call''"},{"id":10,"trace":"activesupport
+        (5.0.0.1) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in
+        `call''"},{"id":11,"trace":"actionpack (5.0.0.1) lib/action_dispatch/middleware/executor.rb:12:in
+        `call''"},{"id":12,"trace":"actionpack (5.0.0.1) lib/action_dispatch/middleware/static.rb:136:in
+        `call''"},{"id":13,"trace":"rack (2.0.1) lib/rack/sendfile.rb:111:in `call''"},{"id":14,"trace":"railties
+        (5.0.0.1) lib/rails/engine.rb:522:in `call''"},{"id":15,"trace":"puma (3.6.0)
+        lib/puma/configuration.rb:225:in `call''"},{"id":16,"trace":"puma (3.6.0)
+        lib/puma/server.rb:578:in `handle_request''"},{"id":17,"trace":"puma (3.6.0)
+        lib/puma/server.rb:415:in `process_client''"},{"id":18,"trace":"puma (3.6.0)
+        lib/puma/server.rb:275:in `block in run''"},{"id":19,"trace":"puma (3.6.0)
+        lib/puma/thread_pool.rb:116:in `block in spawn_thread''"}]}}'
+    http_version: 
+  recorded_at: Tue, 21 Feb 2017 12:03:46 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Parliament_Request/_get/it_returns_a_status_code_in_either_the_400_or_500_range/and_raises_server_error_when_status_is_within_the_500_range.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Request/_get/it_returns_a_status_code_in_either_the_400_or_500_range/and_raises_server_error_when_status_is_within_the_500_range.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/parties/current
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - localhost:3030
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/n-triples; charset=utf-8
+      Etag:
+      - W/"185aa74d646459e732be3b0e22099983"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 7116de7a-dea2-42d1-9ed3-896d2a51db45
+      X-Runtime:
+      - '0.074673'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        <http://id.ukpds.org/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
+        <http://id.ukpds.org/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427> <http://id.ukpds.org/schema/partyName> "Labour" .
+        <http://id.ukpds.org/ab77ae5d-7559-4636-ac25-2a23fd961980> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
+        <http://id.ukpds.org/ab77ae5d-7559-4636-ac25-2a23fd961980> <http://id.ukpds.org/schema/partyName> "Conservative" .
+        <http://id.ukpds.org/98f0d50d-d9f7-49e3-a9ad-4f7ddaf08349> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
+        <http://id.ukpds.org/98f0d50d-d9f7-49e3-a9ad-4f7ddaf08349> <http://id.ukpds.org/schema/partyName> "Independent" .
+        <http://id.ukpds.org/0aed9061-7b9b-42f1-b3a8-0427460789d8> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
+        <http://id.ukpds.org/0aed9061-7b9b-42f1-b3a8-0427460789d8> <http://id.ukpds.org/schema/partyName> "Green Party" .
+        <http://id.ukpds.org/28a6df70-572f-4063-ab51-ac5457f352bb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
+        <http://id.ukpds.org/28a6df70-572f-4063-ab51-ac5457f352bb> <http://id.ukpds.org/schema/partyName> "Scottish National Party" .
+        <http://id.ukpds.org/35571d66-6467-420c-bc8d-f5a8ad1b4d70> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
+        <http://id.ukpds.org/35571d66-6467-420c-bc8d-f5a8ad1b4d70> <http://id.ukpds.org/schema/partyName> "Democratic Unionist Party" .
+        <http://id.ukpds.org/cab7185a-bbf9-406d-9370-2f4ddb4b1abb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
+        <http://id.ukpds.org/cab7185a-bbf9-406d-9370-2f4ddb4b1abb> <http://id.ukpds.org/schema/partyName> "Liberal Democrat" .
+        <http://id.ukpds.org/6397ae29-84e6-4954-96a9-1569eec7af62> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
+        <http://id.ukpds.org/6397ae29-84e6-4954-96a9-1569eec7af62> <http://id.ukpds.org/schema/partyName> "Plaid Cymru" .
+        <http://id.ukpds.org/87c864b0-d4f2-47f9-971b-b7f71946f252> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
+        <http://id.ukpds.org/87c864b0-d4f2-47f9-971b-b7f71946f252> <http://id.ukpds.org/schema/partyName> "Social Democratic & Labour Party" .
+        <http://id.ukpds.org/efec7559-21d9-46c3-8c6f-9dc503c26a44> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
+        <http://id.ukpds.org/efec7559-21d9-46c3-8c6f-9dc503c26a44> <http://id.ukpds.org/schema/partyName> "Speaker" .
+        <http://id.ukpds.org/8c14793a-e195-48bf-a9c2-ab06eef8c9a9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
+        <http://id.ukpds.org/8c14793a-e195-48bf-a9c2-ab06eef8c9a9> <http://id.ukpds.org/schema/partyName> "Sinn Fein" .
+        <http://id.ukpds.org/5b6e2e81-d440-45f8-a03e-f7f161d0ad4e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
+        <http://id.ukpds.org/5b6e2e81-d440-45f8-a03e-f7f161d0ad4e> <http://id.ukpds.org/schema/partyName> "Ulster Unionist Party" .
+        <http://id.ukpds.org/b24cf8e0-9552-4ea8-a102-134a395aaf18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
+        <http://id.ukpds.org/b24cf8e0-9552-4ea8-a102-134a395aaf18> <http://id.ukpds.org/schema/partyName> "UK Independence Party" .
+    http_version: 
+  recorded_at: Tue, 21 Feb 2017 12:03:46 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Parliament_Request/_get/it_returns_a_status_code_of_200_and_/returns_27_objects.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Request/_get/it_returns_a_status_code_of_200_and_/returns_27_objects.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/current.nt
+    uri: http://localhost:3030/parties/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Request/_get/it_returns_a_status_code_of_200_and_/returns_a_Parliament_Response.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Request/_get/it_returns_a_status_code_of_200_and_/returns_a_Parliament_Response.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/current.nt
+    uri: http://localhost:3030/parties/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Request/_get/it_returns_a_status_code_of_200_and_/returns_an_array_of_Grom_Node_objects.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Request/_get/it_returns_a_status_code_of_200_and_/returns_an_array_of_Grom_Node_objects.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/current.nt
+    uri: http://localhost:3030/parties/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Request/_get/it_returns_a_status_code_of_200_and_/returns_linked_objects_where_links_are_in_the_data.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Request/_get/it_returns_a_status_code_of_200_and_/returns_linked_objects_where_links_are_in_the_data.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/members/current.nt
+    uri: http://localhost:3030/people/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Request/_get/it_returns_a_status_code_of_204_and_/raises_a_Parliament_NoContentError.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Request/_get/it_returns_a_status_code_of_204_and_/raises_a_Parliament_NoContentError.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/321f496b-5c8b-4455-ab49-a96e42b34739/parties/current.nt
+    uri: http://localhost:3030/people/321f496b-5c8b-4455-ab49-a96e42b34739/parties/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Request/_get/it_returns_a_status_code_of_204_and_/returns_a_Parliament_Response.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Request/_get/it_returns_a_status_code_of_204_and_/returns_a_Parliament_Response.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/321f496b-5c8b-4455-ab49-a96e42b34739/parties/current.nt
+    uri: http://localhost:3030/people/321f496b-5c8b-4455-ab49-a96e42b34739/parties/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Response/_filter/confirms_that_each_Grom_Node_is_of_type_Person.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Response/_filter/confirms_that_each_Grom_Node_is_of_type_Person.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/members/current.nt
+    uri: http://localhost:3030/people/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Response/_filter/returns_a_response_filtered_by_a_single_type.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Response/_filter/returns_a_response_filtered_by_a_single_type.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/members/current.nt
+    uri: http://localhost:3030/people/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Response/_filter/returns_an_array_of_arrays_of_objects_filtered_by_type_Party.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Response/_filter/returns_an_array_of_arrays_of_objects_filtered_by_type_Party.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/members/current.nt
+    uri: http://localhost:3030/people/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Response/_filter/returns_an_array_of_arrays_of_objects_filtered_by_type_Person.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Response/_filter/returns_an_array_of_arrays_of_objects_filtered_by_type_Person.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/members/current.nt
+    uri: http://localhost:3030/people/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Response/_filter/returns_an_empty_array_of_response_objects_when_the_type_passed_in_does_not_exist.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Response/_filter/returns_an_empty_array_of_response_objects_when_the_type_passed_in_does_not_exist.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/members/current.nt
+    uri: http://localhost:3030/people/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Response/_filter/returns_an_empty_array_when_no_types_are_passed_in.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Response/_filter/returns_an_empty_array_when_no_types_are_passed_in.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/members/current.nt
+    uri: http://localhost:3030/people/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Parliament_Response/_filter/returns_an_empty_array_when_the_response_is_empty.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Response/_filter/returns_an_empty_array_when_the_response_is_empty.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/members/current.nt
+    uri: http://localhost:3030/people/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/parliament/request_spec.rb
+++ b/spec/parliament/request_spec.rb
@@ -100,7 +100,7 @@ describe Parliament::Request, vcr: true do
 
     context 'it returns a status code in either the 400 or 500 range' do
       it 'and raises client error when status is within the 400 range' do
-        stub_request(:get, 'http://localhost:3030/dogs/cats.nt').to_return(status: 400)
+        stub_request(:get, 'http://localhost:3030/dogs/cats').to_return(status: 400)
 
         expect do
           Parliament::Request.new(base_url: 'http://localhost:3030').dogs.cats.get
@@ -108,11 +108,29 @@ describe Parliament::Request, vcr: true do
       end
 
       it 'and raises server error when status is within the 500 range' do
-        stub_request(:get, 'http://localhost:3030/parties/current.nt').to_return(status: 500)
+        stub_request(:get, 'http://localhost:3030/parties/current').to_return(status: 500)
 
         expect do
           Parliament::Request.new(base_url: 'http://localhost:3030').parties.current.get
         end.to raise_error(StandardError, 'This is a HTTPServerError')
+      end
+    end
+
+    xcontext 'it accepts query parameters' do
+      subject { Parliament::Request.new(base_url: 'http://localhost:3030').people.get(params: {by: 'wiki', value: '123'}) }
+
+      it 'returns a Parliament::Response' do
+        expect(subject).to be_a(Parliament::Response)
+      end
+
+      it 'returns 27 objects' do
+        expect(subject.size).to eq(27)
+      end
+
+      it 'returns an array of Grom::Node objects' do
+        subject.each do |object|
+          expect(object).to be_a(Grom::Node)
+        end
       end
     end
   end

--- a/spec/parliament/request_spec.rb
+++ b/spec/parliament/request_spec.rb
@@ -117,7 +117,7 @@ describe Parliament::Request, vcr: true do
     end
 
     context 'it accepts query parameters' do
-      subject { Parliament::Request.new(base_url: 'http://localhost:3030').people.get(params: { by: 'mnisId', id: '3898' }) }
+      subject { Parliament::Request.new(base_url: 'http://localhost:3030').people.get(params: { source: 'mnisId', id: '3898' }) }
 
       it 'returns a Parliament::Response' do
         expect(subject).to be_a(Parliament::Response)

--- a/spec/parliament/request_spec.rb
+++ b/spec/parliament/request_spec.rb
@@ -116,21 +116,15 @@ describe Parliament::Request, vcr: true do
       end
     end
 
-    xcontext 'it accepts query parameters' do
-      subject { Parliament::Request.new(base_url: 'http://localhost:3030').people.get(params: {by: 'wiki', value: '123'}) }
+    context 'it accepts query parameters' do
+      subject { Parliament::Request.new(base_url: 'http://localhost:3030').people.get(params: { by: 'mnisId', id: '3898' }) }
 
       it 'returns a Parliament::Response' do
         expect(subject).to be_a(Parliament::Response)
       end
 
-      it 'returns 27 objects' do
-        expect(subject.size).to eq(27)
-      end
-
-      it 'returns an array of Grom::Node objects' do
-        subject.each do |object|
-          expect(object).to be_a(Grom::Node)
-        end
+      it 'returns 1 object' do
+        expect(subject.size).to eq(1)
       end
     end
   end


### PR DESCRIPTION
- Implemented the handling of query parameters in Parliament::Request
- Removed .nt from the end of all api urls as this is no longer necessary
- Removed pry dependencies - these should not be left in when the gem is to be deployed