### PR TITLE
Add build target to checkout version from latest release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,15 @@
+.PHONY: checkout_to_release
+
+# Github variables
+GITHUB_API=https://api.github.com
+ORG=ukparliament
+REPO=parliament-ruby
+LATEST_REL=$(GITHUB_API)/repos/$(ORG)/$(REPO)/releases
+REL_TAG=$(shell curl -s $(LATEST_REL) | jq -r '.[0].tag_name')
+
+checkout_to_release:
+	git checkout -b release $(REL_TAG)
+
 gemset:
 	rvm gemset create parliament-ruby
 	rvm --force gemset empty parliament-ruby


### PR DESCRIPTION
This will facilitate triggering Go.CD builds on creation of a tag/release.